### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/LeoriumDev/serdec/security/code-scanning/1](https://github.com/LeoriumDev/serdec/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the workflow level (root level) to explicitly define the least privileges required. Since the workflow only checks out the repository and builds the project, it only needs `contents: read` permissions. This ensures that the `GITHUB_TOKEN` used in the workflow has minimal access, reducing the risk of unintended actions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
